### PR TITLE
Increase olcDbMaxSize

### DIFF
--- a/slapd/__init__.py
+++ b/slapd/__init__.py
@@ -42,6 +42,7 @@ olcSuffix: %(suffix)s
 olcRootDN: %(rootdn)s
 olcRootPW: %(rootpw)s
 olcDbDirectory: %(directory)s
+olcDbMaxSize: 1000000000
 """
 
 


### PR DESCRIPTION
This way the database can handle more items by default.