### PR TITLE
Use poetry-core as build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["poetry>=1.0.0"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool]
 [tool.poetry]


### PR DESCRIPTION
The poetry build backend was split into the package poetry-core.

Fixing this would make things easier for us at Nixpkgs, as we currently need to patch your `pyproject.toml` for this.

See also
Recommendation on how to use pyproject.toml: https://python-poetry.org/docs/pyproject/#poetry-and-pep-517
Nixpkgs issue: https://github.com/NixOS/nixpkgs/issues/103325